### PR TITLE
Remove projectCards from graphql query

### DIFF
--- a/code-review-github.el
+++ b/code-review-github.el
@@ -187,13 +187,6 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           login
         }
       }
-      projectCards(first: 10) {
-        nodes {
-          project {
-            name
-          }
-        }
-      }
       suggestedReviewers {
         reviewer {
           name
@@ -361,13 +354,6 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           name
           login
           url
-        }
-      }
-      projectCards(first: 10) {
-        nodes {
-          project {
-            name
-          }
         }
       }
       suggestedReviewers {


### PR DESCRIPTION
Github removed `projectCards` from their graphql schema on April 1st ([sunset notice](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/)) which caused some errors in code-review when fetching the data.

Fixes https://github.com/wandersoncferreira/code-review/issues/262