### PR TITLE
Use vector for 'comments field in github

### DIFF
--- a/code-review-github.el
+++ b/code-review-github.el
@@ -745,15 +745,15 @@ Optionally ask for the FALLBACK? query."
                       (a-assoc payload 'body (oref review feedback))
                     payload))
          (payload (if (oref review local-comments)
-                      (a-assoc payload 'comments (--sort
-                                                  (< (a-get it 'position)
-                                                     (a-get other 'position))
-                                                  (-map
-                                                   (lambda (c)
-                                                     `((path . ,(oref c path))
-                                                       (position . ,(oref c position))
-                                                       (body . ,(oref c body))))
-                                                   (oref review local-comments))))
+                      (a-assoc payload 'comments (vconcat (--sort
+                                                           (< (a-get it 'position)
+                                                              (a-get other 'position))
+                                                           (-map
+                                                            (lambda (c)
+                                                              `((path . ,(oref c path))
+                                                               (position . ,(oref c position))
+                                                               (body . ,(oref c body))))
+                                                            (oref review local-comments)))))
                     payload)))
     (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"
                        (oref pr owner)


### PR DESCRIPTION
## Summary
I tried using code-review for the first time today, and ran into an issue with serializing my comments.
```
Debugger entered--Lisp error: (wrong-type-argument symbolp (path . "<some_file_in_the_review>"))
```
After some local debugging, I found out that json-serialize expects a vector if we want the contents to be represented as a list. 

The reason this wasn't broken before is that ghub supported lists as inputs, but recently stopped supporting it in favor of passing the payload through to json-serialize directly.

In https://github.com/magit/ghub/pull/168 :
> Decoding should work as before. When it comes to encoding we inherit a backward incompatible change. Lists, or more accurately "JSON arrays", now have to be specified using Lisp vectors, not Lisp lists. Adapting to that should be fairly simple. In Forge, for example, this was needed: https://github.com/magit/forge/commit/4247e53b811fbce009612597f5ee214747c692a7.

## Changes
- Massage the existing comments list into a vector

## Notes
- I'm making the PR here since the original repo seems dead, but I'll put up an issue there in case folks want to find this fix (I found this fork through #3, which solved the first error that I encountered when using code-review)
- Please let me know if I need to change the formatting or anything else!