### PR TITLE
Use vector for github labels api request

### DIFF
--- a/code-review-github.el
+++ b/code-review-github.el
@@ -529,9 +529,9 @@ Optionally ask for the FALLBACK? query."
     (message "Sending new labels...")
     (funcall req-fn url
              nil
-             :payload (a-alist 'labels (or (-map (lambda (x)
+             :payload (a-alist 'labels (or (vconcat (-map (lambda (x)
                                                    (a-get x 'name))
-                                                 (oref github labels))
+                                                 (oref github labels)))
                                            []))
              :auth code-review-auth-login-marker
              :host code-review-github-host


### PR DESCRIPTION
The transient "set labels" feature is broken for GitHub. This applies the same fix as  [303edcf](https://github.com/doomelpa/code-review/commit/303edcfbad8190eccb9a9269dfc58ed26d386ba5) did for comments to labels.