### PR TITLE
Support GitHub reviews with ghub 5.1

### DIFF
--- a/code-review-github.el
+++ b/code-review-github.el
@@ -29,6 +29,12 @@
 ;;; Code:
 
 (require 'ghub)
+;; `ghub-graphql' moved to `ghub-legacy' in Ghub 5.0 and `ghub'
+;; stopped loading that file in Ghub 5.1.  Keep working with both older
+;; Ghub versions, where `ghub' still defines `ghub-graphql', and newer
+;; ones, where the compatibility wrapper has to be loaded explicitly.
+(unless (fboundp 'ghub-graphql)
+  (require 'ghub-legacy nil t))
 (require 'deferred)
 (require 'code-review-interfaces)
 (require 'code-review-db)


### PR DESCRIPTION
Ghub 5 moved the obsolete ghub-graphql helper out of ghub-graphql.el and
into ghub-legacy.el. Ghub 5.0 still loaded ghub-legacy from ghub.el, but
Ghub 5.1 stopped doing so, leaving code-review's GitHub metadata fetch
with (void-function ghub-graphql).

Load ghub-legacy only when ghub-graphql is not already defined. This
keeps compatibility with older ghub releases that still provide
ghub-graphql through (require 'ghub), while restoring compatibility with
newer ghub releases where the legacy wrapper must be loaded explicitly.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>